### PR TITLE
Update HMM.py

### DIFF
--- a/Ch16/HMM.py
+++ b/Ch16/HMM.py
@@ -70,7 +70,7 @@ def Viterbi(pi,a,b,obs):
 
 	path[T-1] = np.argmax(delta[:,T-1])
 	for t in range(T-2,-1,-1):
-		path[t] = phi[path[t+1],t+1]
+		path[t] = phi[int(path[t+1]),t+1]
 
 	return path,delta, phi
 


### PR DESCRIPTION
Fixes the following error due to trying to index with a float 
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

in python 3.8 numpy 1.20.2